### PR TITLE
support  apple m1

### DIFF
--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -63,6 +63,9 @@ function getMediaGetRemoteFilename(latestVersion) {
     }
     if (isDarwin) {
         suffix = 'darwin';
+        if (process.arch === 'x64') {
+            suffix += '-arm64';
+        }
     }
     if (process.arch === 'arm64') {
         suffix += '-arm64';


### PR DESCRIPTION
apple m1 这里的`process.arch` 值是`x64` 并不是`arm64`