### PR TITLE
Add onlyCreatedPlaylists option to filter cloud sync to user-created playlists

### DIFF
--- a/backend/src/service/account.js
+++ b/backend/src/service/account.js
@@ -19,6 +19,7 @@ const defaultConfig = {
           enable: false,
           frequency: 1,
           frequencyUnit: "day",
+          onlyCreatedPlaylists: true,
         },
         syncWySong: true,
         syncNotWySong: false,

--- a/backend/src/service/scheduler/index.js
+++ b/backend/src/service/scheduler/index.js
@@ -97,7 +97,11 @@ class SchedulerService {
         this.jobs.set(jobKey, schedule.scheduleJob(rule, async () => {
             logger.info(`Start cloud sync for account ${uid}`);
             const playlists = await getUserAllPlaylist(uid);
-            for (const playlist of playlists) {
+            // Filter playlists based on user preference
+            const playlistsToSync = account.config.playlistSyncToWyCloudDisk.autoSync.onlyCreatedPlaylists
+                ? playlists.filter(p => p.isCreatedByMe)
+                : playlists;
+            for (const playlist of playlistsToSync) {
                 logger.info(`Start sync playlist ${playlist.id} to cloud for account ${uid}`);
                 await unblockMusicInPlaylist(uid, sourceConsts.Netease.code, playlist.id, {
                     syncWySong: account.config.playlistSyncToWyCloudDisk.syncWySong,

--- a/frontend/src/views/pc/Account.vue
+++ b/frontend/src/views/pc/Account.vue
@@ -248,6 +248,14 @@
                   <div class="sync-options">
                     <el-checkbox
                       v-model="
+                        account.config.playlistSyncToWyCloudDisk.autoSync.onlyCreatedPlaylists
+                      "
+                    >
+                      仅同步我创建的歌单
+                      <el-tag size="small" type="success">推荐</el-tag>
+                    </el-checkbox>
+                    <el-checkbox
+                      v-model="
                         account.config.playlistSyncToWyCloudDisk.syncWySong
                       "
                     >
@@ -625,6 +633,7 @@ export default {
               enable: false,
               frequency: 1,
               frequencyUnit: "day",
+              onlyCreatedPlaylists: true,
             },
             syncWySong: true,
             syncNotWySong: false,


### PR DESCRIPTION
Cloud sync currently uploads songs from all playlists (user-created + favorited), which can be excessive. Users should be able to sync only their created playlists.

close #168 