### PR TITLE
fix: 修复从官方源下载无损歌曲时的文件名后缀错误

### DIFF
--- a/backend/src/service/music_platform/wycloud/index.js
+++ b/backend/src/service/music_platform/wycloud/index.js
@@ -129,6 +129,21 @@ async function getPlayUrl(uid, id, isLossless = false) {
     return response.data[0].url;
 }
 
+async function getPlayUrlWithType(uid, id, isLossless = false) {
+    const response = await safeRequest(uid, song_url, {
+        id,
+        br: isLossless ? 999000 : 320000
+    });
+    if (response === false || !response.data || !response.data[0].url) {
+        return { url: '', type: 'mp3' , level: ''};
+    }
+    return {
+        url: response.data[0].url,
+        type: response.data[0].type.toLowerCase() || 'mp3', //实际上，有可能返回“MP3”，这个值会成为文件的扩展名，要toLowerCase()
+        level: response.data[0].level || '',
+    };
+}
+
 async function getUserAllPlaylist(uid) {
     const wyAccount = await getMyAccount(uid);
     if (wyAccount === false) {
@@ -314,6 +329,7 @@ module.exports = {
     getUserAllPlaylist: getUserAllPlaylist,
     getSongInfo: getSongInfo,
     getPlayUrl: getPlayUrl,
+    getPlayUrlWithType: getPlayUrlWithType,
     qrLoginCreate: qrLoginCreate,
     qrLoginCheck: qrLoginCheck,
     verifyAccountStatus: verifyAccountStatus,

--- a/backend/src/service/sync_music/sync_playlist.js
+++ b/backend/src/service/sync_music/sync_playlist.js
@@ -1,6 +1,7 @@
 const {
   getSongsFromPlaylist,
   getPlayUrl,
+  getPlayUrlWithType,
 } = require("../music_platform/wycloud");
 const syncSingleSongWithUrl = require("./sync_single_song_with_url");
 const logger = require("consola");
@@ -138,19 +139,20 @@ async function syncSingleSong(uid, wySongMeta, playlistInfo) {
     isLossless = true;
   }
   // 优先使用官方资源下载
-  const playUrl = await getPlayUrl(uid, wySongMeta.songId, isLossless);
-  if (playUrl) {
-    const tmpPath = await downloadViaSourceUrl(playUrl);
+  const playInfo = await getPlayUrlWithType(uid, wySongMeta.songId, isLossless);
+  if (playInfo.url) {
+    const tmpPath = await downloadViaSourceUrl(playInfo.url);
     if (tmpPath) {
         const collectRet = {};
       const ret = await downloadFromLocalTmpPath(
         tmpPath,
         wySongMeta,
         playlistName,
-        collectRet
+        collectRet,
+        playInfo.type
       );
       if (ret === true) {
-        logger.info(`download from official succeed`, wySongMeta);
+        logger.info(`download from official succeed`, wySongMeta,"with type:", playInfo.type," level:", playInfo.level);
         if (collectRet.md5Value) {
             await recordSongIndex(playlistID, wySongMeta.songId, wySongMeta, playlistName, collectRet.md5Value);
         }


### PR DESCRIPTION
根据API返回的type与level,生成正确的文件名后缀，并再日志中记录下载歌曲的文件类型与音质等级。